### PR TITLE
fixing StackOverflowError

### DIFF
--- a/src/org/openstreetmap/josm/plugins/Splinex/DrawSplineAction.java
+++ b/src/org/openstreetmap/josm/plugins/Splinex/DrawSplineAction.java
@@ -56,7 +56,7 @@ public class DrawSplineAction extends MapMode implements MapViewPaintable, KeyPr
     public DrawSplineAction(MapFrame mapFrame) {
         super(tr("Spline drawing"), // name
                 "spline2", // icon name
-                tr("Draw a spline curve (dev)"), // tooltip
+                tr("Draw a spline curve"), // tooltip
                 mapFrame, getCursor());
 
         backspaceShortcut = Shortcut.registerShortcut("mapmode:backspace", tr("Backspace in Add mode"),

--- a/src/org/openstreetmap/josm/plugins/Splinex/DrawSplineAction.java
+++ b/src/org/openstreetmap/josm/plugins/Splinex/DrawSplineAction.java
@@ -56,7 +56,7 @@ public class DrawSplineAction extends MapMode implements MapViewPaintable, KeyPr
     public DrawSplineAction(MapFrame mapFrame) {
         super(tr("Spline drawing"), // name
                 "spline2", // icon name
-                tr("Draw a spline curve"), // tooltip
+                tr("Draw a spline curve (dev)"), // tooltip
                 mapFrame, getCursor());
 
         backspaceShortcut = Shortcut.registerShortcut("mapmode:backspace", tr("Backspace in Add mode"),
@@ -276,9 +276,9 @@ public class DrawSplineAction extends MapMode implements MapViewPaintable, KeyPr
             ph.movePoint(en);
             if (lockCounterpart) {
                 if (ph.point == SplinePoint.CONTROL_NEXT)
-                    ph.sn.cprev = ph.sn.cnext.sub(new EastNorth(0, 0));
+                    ph.sn.cprev = new EastNorth(0, 0).subtract(ph.sn.cnext);
                 else if (ph.point == SplinePoint.CONTROL_PREV)
-                    ph.sn.cnext = ph.sn.cprev.sub(new EastNorth(0, 0));
+                    ph.sn.cnext = new EastNorth(0, 0).subtract(ph.sn.cprev);
             }
         }
         Main.map.repaint();

--- a/src/org/openstreetmap/josm/plugins/Splinex/Spline.java
+++ b/src/org/openstreetmap/josm/plugins/Splinex/Spline.java
@@ -170,10 +170,10 @@ public class Spline {
                 sn.node.setEastNorth(en);
                 return;
             case CONTROL_PREV:
-                sn.cprev = sn.node.getEastNorth().sub(en);
+                sn.cprev = en.subtract(sn.node.getEastNorth());
                 return;
             case CONTROL_NEXT:
-                sn.cnext = sn.node.getEastNorth().sub(en);
+                sn.cnext = en.subtract(sn.node.getEastNorth());
                 return;
             }
             throw new AssertionError();

--- a/src/org/openstreetmap/josm/plugins/Splinex/SplineHitTest.java
+++ b/src/org/openstreetmap/josm/plugins/Splinex/SplineHitTest.java
@@ -70,6 +70,8 @@ public class SplineHitTest {
         double y1234 = (y123 + y234) / 2;
         if (checkPoint(x1234, y1234))
             return true;
+        if (Math.abs(x1-x1234)<0.0001 && Math.abs(y1-y1234)<0.0001)
+            return false; // avoid infinite loop
         return checkCurve(x1, y1, x12, y12, x123, y123, x1234, y1234)
             || checkCurve(x1234, y1234, x234, y234, x34, y34, x4, y4);
     }


### PR DESCRIPTION
There was a StackOverflowError when spline had (only) a straight line and mouse was moved over that. SplineHitTest.checkCurve called itself with the same parameters many times. Fixed infinite recursion by checking parameters.
